### PR TITLE
Add ephemeral ports feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,12 @@ cd frankenphp-joomla
 docker compose pull --include-deps
 docker compose up
 ```
-Your Joomla website is available on `https://localhost`.
+
+Your Joomla website is available on `https://localhost:{random_ephemeral_port}`.
+
+In this case `{random_ephemeral_port}` is the first random port that is available that does not conflict with other
+services. `e.g. 51042`
+
+Check `docker compose ps` to find the ephemeral port used. It prevents port clashing (open ports conflicts).
+
 Check `docker-compose.yml` to find DB credentials.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     build: .
     restart: always
     ports:
-      - 80:80
-      - 443:443
+      - ::80
+      - ::443
     environment:
       JOOMLA_DB_HOST: db
       JOOMLA_DB_USER: exampleuser


### PR DESCRIPTION
Helps prevent port clashing conflicts when starting the services by using ephemeral port feature supported by docker-compose. ::internal_port/internal_protocol syntax e.g. `::443/tcp`

CAVEAT: Now port will always be different on restart of the corresponding service. You might what to use a reverse-proxy in front of the service like NginX, Traefik, etc...