### PR TITLE
Deactive localhost check for Joomla installation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       JOOMLA_DB_USER: exampleuser
       JOOMLA_DB_PASSWORD: examplepass
       JOOMLA_DB_NAME: exampledb
+      JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK: 1
     volumes:
       - joomla:/app/public
 


### PR DESCRIPTION
since JOOMLA_DB_HOST != localhost an environment variable is required, to enable the installation with a 'remote' database, which in this case is a different container

see https://docs.joomla.org/J3.x:Secured_procedure_for_installing_Joomla_with_a_remote_database